### PR TITLE
Fix crash when unspent xact has native segwit outputs

### DIFF
--- a/glacierscript.py
+++ b/glacierscript.py
@@ -298,6 +298,9 @@ def get_utxos(tx, address):
     utxos = []
 
     for output in tx["vout"]:
+        if "addresses" not in output["scriptPubKey"]:
+            # In Bitcoin Core versions older than v0.16, native segwit outputs have no address decoded
+            continue
         out_addresses = output["scriptPubKey"]["addresses"]
         amount_btc = output["value"]
         if address in out_addresses:


### PR DESCRIPTION
Fixes issue #14.

Basically, we want to ignore any output that does not have any key "addresses" in its scriptPubKey.

See [branch segwit-tests in my fork](https://github.com/bitcoinhodler/GlacierProtocol/commits/segwit-tests) for an automated test for this fix. I also have other automated tests there which continued to pass after this fix.
