### PR TITLE
Use new Bitcoin Core v0.17 APIs

### DIFF
--- a/glacierscript.py
+++ b/glacierscript.py
@@ -252,7 +252,7 @@ def ensure_bitcoind_running():
     #
     # The only way to make our signrawtransaction compatible with both 0.16 and 0.17 is using this -deprecatedrpc=signrawtransaction..
     # Once Bitcoin Core v0.17 is published on the Ubuntu PPA we should:
-    # 1. Convert signrawtransaction to signrawtransactionwithkeys (note, argument order changes)
+    # 1. [done] Convert signrawtransaction to signrawtransactionwithkey (note, argument order changes)
     # 2. Remove this -deprecatedrpc=signrawtransaction
     # 3. Change getaddressesbyaccount to getaddressesbylabel
     # 4. Remove this -deprecatedrpc=accounts
@@ -408,9 +408,9 @@ def sign_transaction(source_address, keys, redeem_script, unsigned_hex, input_tx
             })
 
     argstring_2 = "{0} '{1}' '{2}'".format(
-        unsigned_hex, json.dumps(inputs), json.dumps(keys))
+        unsigned_hex, json.dumps(keys), json.dumps(inputs))
     signed_hex = subprocess.check_output(
-        bitcoin_cli + "signrawtransaction {0}".format(argstring_2), shell=True).strip()
+        bitcoin_cli + "signrawtransactionwithkey {0}".format(argstring_2), shell=True).strip()
 
     signed_tx = json.loads(signed_hex)
     return signed_tx
@@ -654,6 +654,7 @@ def withdraw_interactive():
 
     safety_checklist()
     ensure_bitcoind_running()
+    require_minimum_bitcoind_version(170000) # signrawtransaction API changed in v0.17.0
 
     approve = False
 

--- a/glacierscript.py
+++ b/glacierscript.py
@@ -286,19 +286,19 @@ def get_address_for_wif_privkey(privkey):
        <privkey> - a bitcoin private key in WIF format"""
 
     # Bitcoin Core doesn't have an RPC for "get the addresses associated w/this private key"
-    # just "get the addresses associated with this account"
-    # where "account" corresponds to an arbitrary tag we can associate with each private key
-    # so, we'll generate a unique "account number" to put this private key into.
+    # just "get the addresses associated with this label"
+    # where "label" corresponds to an arbitrary tag we can associate with each private key
+    # so, we'll generate a unique "label" to attach to this private key.
     #
     # we're running on a fresh bitcoind installation in the Glacier Protocol, so there's no
-    # meaningful risk here of colliding with previously-existing account numbers.
-    account_number = random.randint(0, 2**128)
+    # meaningful risk here of colliding with previously-existing labels.
+    label = random.randint(0, 2**128)
 
     ensure_bitcoind_running()
     subprocess.call(
-        bitcoin_cli + "importprivkey {0} {1}".format(privkey, account_number), shell=True)
+        bitcoin_cli + "importprivkey {0} {1}".format(privkey, label), shell=True)
     addresses = subprocess.check_output(
-        bitcoin_cli + "getaddressesbylabel {0}".format(account_number), shell=True)
+        bitcoin_cli + "getaddressesbylabel {0}".format(label), shell=True)
 
     # extract address from JSON output
     addresses_json = json.loads(addresses)

--- a/glacierscript.py
+++ b/glacierscript.py
@@ -255,8 +255,8 @@ def ensure_bitcoind_running():
     # 1. [done] Convert signrawtransaction to signrawtransactionwithkey (note, argument order changes)
     # 2. [done] Remove this -deprecatedrpc=signrawtransaction
     # 3. [done] Change getaddressesbyaccount to getaddressesbylabel
-    # 4. Remove this -deprecatedrpc=accounts
-    subprocess.call(bitcoind + "-daemon -connect=0.0.0.0 -deprecatedrpc=accounts",
+    # 4. [done] Remove this -deprecatedrpc=accounts
+    subprocess.call(bitcoind + "-daemon -connect=0.0.0.0",
                     shell=True, stdout=devnull, stderr=devnull)
 
     # verify bitcoind started up and is functioning correctly

--- a/glacierscript.py
+++ b/glacierscript.py
@@ -312,8 +312,6 @@ def addmultisigaddress(m, addresses_or_pubkeys, address_type='p2sh-segwit'):
     m: <int> number of multisig keys required for withdrawal
     addresses_or_pubkeys: List<string> either addresses or hex pubkeys for each of the N keys
     """
-
-    require_minimum_bitcoind_version(160000) # addmultisigaddress API changed in v0.16.0
     address_string = json.dumps(addresses_or_pubkeys)
     argstring = "{0} '{1}' '' '{2}'".format(m, address_string, address_type)
     return json.loads(subprocess.check_output(

--- a/glacierscript.py
+++ b/glacierscript.py
@@ -249,13 +249,6 @@ def ensure_bitcoind_running():
     # message (to /dev/null) and exit.
     #
     # -connect=0.0.0.0 because we're doing local operations only (and have no network connection anyway)
-    #
-    # The only way to make our signrawtransaction compatible with both 0.16 and 0.17 is using this -deprecatedrpc=signrawtransaction..
-    # Once Bitcoin Core v0.17 is published on the Ubuntu PPA we should:
-    # 1. [done] Convert signrawtransaction to signrawtransactionwithkey (note, argument order changes)
-    # 2. [done] Remove this -deprecatedrpc=signrawtransaction
-    # 3. [done] Change getaddressesbyaccount to getaddressesbylabel
-    # 4. [done] Remove this -deprecatedrpc=accounts
     subprocess.call(bitcoind + "-daemon -connect=0.0.0.0",
                     shell=True, stdout=devnull, stderr=devnull)
 

--- a/glacierscript.py
+++ b/glacierscript.py
@@ -302,6 +302,12 @@ def get_address_for_wif_privkey(privkey):
 
     # extract address from JSON output
     addresses_json = json.loads(addresses)
+
+    # getaddressesbyaccount returns multiple addresses associated with
+    # this one privkey; since we use it only for communicating the
+    # pubkey to addmultisigaddress, it doesn't matter which one we
+    # choose; they are all associated with the same pubkey.
+
     return addresses_json[0]
 
 

--- a/glacierscript.py
+++ b/glacierscript.py
@@ -253,10 +253,10 @@ def ensure_bitcoind_running():
     # The only way to make our signrawtransaction compatible with both 0.16 and 0.17 is using this -deprecatedrpc=signrawtransaction..
     # Once Bitcoin Core v0.17 is published on the Ubuntu PPA we should:
     # 1. [done] Convert signrawtransaction to signrawtransactionwithkey (note, argument order changes)
-    # 2. Remove this -deprecatedrpc=signrawtransaction
+    # 2. [done] Remove this -deprecatedrpc=signrawtransaction
     # 3. Change getaddressesbyaccount to getaddressesbylabel
     # 4. Remove this -deprecatedrpc=accounts
-    subprocess.call(bitcoind + "-daemon -connect=0.0.0.0 -deprecatedrpc=signrawtransaction -deprecatedrpc=accounts",
+    subprocess.call(bitcoind + "-daemon -connect=0.0.0.0 -deprecatedrpc=accounts",
                     shell=True, stdout=devnull, stderr=devnull)
 
     # verify bitcoind started up and is functioning correctly


### PR DESCRIPTION
Now that Bitcoin Core v0.17.0 has been released on the Ubuntu PPA, we can update GlacierScript to use the new APIs available, instead of the deprecated ones that were necessary for compatibility with v0.16.

Also see #37