### PR TITLE
Add verbose flag -v to GlacierScript

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@
 
 SHELL := /bin/bash
 
-all-tests := $(addsuffix .test, $(basename $(wildcard t/*.run)))
+all-tests := $(sort $(addsuffix .test, $(basename $(wildcard t/*.run))))
 
 .PHONY : prereqs test all %.test
 

--- a/glacierscript.py
+++ b/glacierscript.py
@@ -126,7 +126,7 @@ def bitcoin_cli_checkoutput(cmd, args):
     return run_subprocess(subprocess.check_output, "bitcoin-cli", cmd, args, silent=False)
 
 
-def bitcoin_cli_json(cmd="", args=""):
+def bitcoin_cli_json(cmd, args=""):
     """
     Run `bitcoin-cli` using subprocess.check_output, parse output as JSON
     """

--- a/glacierscript.py
+++ b/glacierscript.py
@@ -115,18 +115,30 @@ def run_subprocess(sub_func, exe, cmd, args, silent=False):
 
 
 def bitcoin_cli_call(cmd="", args="", **optargs):
+    """
+    Run `bitcoin-cli` using subprocess.call
+    """
     return run_subprocess(subprocess.call, bitcoin_cli, cmd, args, **optargs)
 
 
 def bitcoin_cli_checkoutput(cmd="", args="", **optargs):
+    """
+    Run `bitcoin-cli` using subprocess.check_output
+    """
     return run_subprocess(subprocess.check_output, bitcoin_cli, cmd, args, **optargs)
 
 
 def bitcoin_cli_json(cmd="", args="", **optargs):
+    """
+    Run `bitcoin-cli` using subprocess.check_output, parse output as JSON
+    """
     return json.loads(bitcoin_cli_checkoutput(cmd, args, **optargs))
 
 
 def bitcoind_call(cmd="", args="", **optargs):
+    """
+    Run `bitcoind` using subprocess.call
+    """
     return run_subprocess(subprocess.call, bitcoind, cmd, args, **optargs)
 
 

--- a/glacierscript.py
+++ b/glacierscript.py
@@ -34,6 +34,7 @@ import random
 import subprocess
 import json
 from decimal import Decimal
+import pipes
 
 # Taken from Gavin Andresen's "bitcointools" python library (exact link in source file)
 from base58 import b58encode
@@ -113,7 +114,7 @@ def run_subprocess(sub_func, exe, *args, **kwargs):
     if silent:
         devnull = open("/dev/null")
         subprocess_args.update({ 'stdout': devnull, 'stderr': devnull })
-    verbose("bitcoin cli call:\n  {0}\n".format(" ".join(cmd_list)))
+    verbose("bitcoin cli call:\n  {0}\n".format(" ".join(pipes.quote(x) for x in cmd_list)))
     cmd_output = sub_func(cmd_list, **subprocess_args)
     verbose("bitcoin cli call {0}:\n  {1}\n".format(verbose_descrip, cmd_output))
     if devnull:

--- a/glacierscript.py
+++ b/glacierscript.py
@@ -863,8 +863,11 @@ if __name__ == "__main__":
     parser.add_argument(
         "-n", type=int, help="Number of total keys required in an m-of-n multisig address creation (default m-of-n = 1-of-2)", default=2)
     parser.add_argument('--testnet', type=int, help=argparse.SUPPRESS)
+    parser.add_argument('-v', action='store_const', default=0, dest='verbose_mode', const=1,
+                        help='increase output verbosity')
     args = parser.parse_args()
 
+    verbose_mode = args.verbose_mode
 
     global cli_args, wif_prefix
     cli_args = ["-testnet", "-rpcport={}".format(args.testnet), "-datadir=bitcoin-test-data"] if args.testnet else []

--- a/glacierscript.py
+++ b/glacierscript.py
@@ -363,7 +363,7 @@ def get_address_for_wif_privkey(privkey):
 
     ensure_bitcoind_running()
     bitcoin_cli_call("importprivkey", privkey, label)
-    addresses = bitcoin_cli_json("getaddressesbylabel", label)
+    addresses = bitcoin_cli_json_nosplit("getaddressesbylabel", label)
 
     # getaddressesbylabel returns multiple addresses associated with
     # this one privkey; since we use it only for communicating the

--- a/glacierscript.py
+++ b/glacierscript.py
@@ -133,7 +133,7 @@ def bitcoin_cli_json(cmd, args=""):
     return json.loads(bitcoin_cli_checkoutput(cmd, args))
 
 
-def bitcoind_call(args="", silent=False):
+def bitcoind_call(args, silent=False):
     """
     Run `bitcoind` using subprocess.call
     """

--- a/glacierscript.py
+++ b/glacierscript.py
@@ -506,7 +506,7 @@ def get_fee_interactive(source_address, keys, destinations, redeem_script, input
         signed_tx = sign_transaction(source_address, keys,
                                      redeem_script, unsigned_tx, input_txs)
 
-        decoded_tx = bitcoin_cli_json("decoderawtransaction", signed_tx["hex"])
+        decoded_tx = bitcoin_cli_json_nosplit("decoderawtransaction", signed_tx["hex"])
         size = decoded_tx["vsize"]
 
         fee = size * fee_basis_satoshis_per_byte

--- a/glacierscript.py
+++ b/glacierscript.py
@@ -342,7 +342,7 @@ def get_address_for_wif_privkey(privkey):
     #
     # we're running on a fresh bitcoind installation in the Glacier Protocol, so there's no
     # meaningful risk here of colliding with previously-existing labels.
-    label = random.randint(0, 2**128)
+    label = str(random.randint(0, 2**128))
 
     ensure_bitcoind_running()
     bitcoin_cli_call("importprivkey", "{0} {1}".format(privkey, label))

--- a/glacierscript.py
+++ b/glacierscript.py
@@ -35,7 +35,6 @@ import subprocess
 import json
 from decimal import Decimal
 import pipes
-import StringIO
 
 # Taken from Gavin Andresen's "bitcointools" python library (exact link in source file)
 from base58 import b58encode
@@ -102,14 +101,11 @@ def run_subprocess(exe, *args):
     """
     cmd_list = [exe] + cli_args + list(args)
     verbose("bitcoin cli call:\n  {0}\n".format(" ".join(pipes.quote(x) for x in cmd_list)))
-    output = StringIO.StringIO()
     pipe = subprocess.Popen(cmd_list, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, bufsize=1)
-    with pipe.stdout:
-        for line in iter(pipe.stdout.readline, b''):
-            output.write(line)
-    retcode = pipe.wait()
-    verbose("bitcoin cli call return code: {0}  output:\n  {1}\n".format(retcode, output.getvalue()))
-    return (cmd_list, retcode, output.getvalue())
+    output, _ = pipe.communicate()
+    retcode = pipe.returncode
+    verbose("bitcoin cli call return code: {0}  output:\n  {1}\n".format(retcode, output))
+    return (cmd_list, retcode, output)
 
 
 def bitcoin_cli_call(*args):

--- a/glacierscript.py
+++ b/glacierscript.py
@@ -860,8 +860,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "-n", type=int, help="Number of total keys required in an m-of-n multisig address creation (default m-of-n = 1-of-2)", default=2)
     parser.add_argument('--testnet', type=int, help=argparse.SUPPRESS)
-    parser.add_argument('-v', action='store_const', default=0, dest='verbose_mode', const=1,
-                        help='increase output verbosity')
+    parser.add_argument('-v', action='store_true', dest='verbose_mode', help='increase output verbosity')
     args = parser.parse_args()
 
     verbose_mode = args.verbose_mode

--- a/glacierscript.py
+++ b/glacierscript.py
@@ -135,11 +135,11 @@ def bitcoin_cli_json(cmd="", args="", **optargs):
     return json.loads(bitcoin_cli_checkoutput(cmd, args, **optargs))
 
 
-def bitcoind_call(cmd="", args="", **optargs):
+def bitcoind_call(args="", **optargs):
     """
     Run `bitcoind` using subprocess.call
     """
-    return run_subprocess(subprocess.call, bitcoind, cmd, args, **optargs)
+    return run_subprocess(subprocess.call, bitcoind, "", args, **optargs)
 
 
 ################################################################################################
@@ -313,7 +313,7 @@ def ensure_bitcoind_running():
     # 2. Remove this -deprecatedrpc=signrawtransaction
     # 3. Change getaddressesbyaccount to getaddressesbylabel
     # 4. Remove this -deprecatedrpc=accounts
-    bitcoind_call("","-daemon -connect=0.0.0.0 -deprecatedrpc=signrawtransaction -deprecatedrpc=accounts", silent=True)
+    bitcoind_call("-daemon -connect=0.0.0.0 -deprecatedrpc=signrawtransaction -deprecatedrpc=accounts", silent=True)
 
     # verify bitcoind started up and is functioning correctly
     times = 0

--- a/glacierscript.py
+++ b/glacierscript.py
@@ -103,7 +103,7 @@ def run_subprocess(sub_func, exe, *args, **kwargs):
     """
     silent = kwargs.pop('silent', False)
     if kwargs: raise TypeError('Unexpected **kwargs: %r' % kwargs)
-    mylist = [exe, cli_args] + list(args)
+    mylist = [exe] + cli_args + list(args)
     full_cmd = " ".join(mylist)
     cmd_list = shlex.split(full_cmd)
     subprocess_args = {}
@@ -865,7 +865,7 @@ if __name__ == "__main__":
 
 
     global cli_args, wif_prefix
-    cli_args = "-testnet -rpcport={} -datadir=bitcoin-test-data".format(args.testnet) if args.testnet else ""
+    cli_args = ["-testnet", "-rpcport={}".format(args.testnet), "-datadir=bitcoin-test-data"] if args.testnet else []
     wif_prefix = "EF" if args.testnet else "80"
 
     if args.program == "entropy":

--- a/glacierscript.py
+++ b/glacierscript.py
@@ -128,7 +128,7 @@ def bitcoin_cli_checkoutput(cmd, *args):
     return run_subprocess(subprocess.check_output, "bitcoin-cli", cmd, *args, silent=False)
 
 
-def bitcoin_cli_json_nosplit(cmd, *args):
+def bitcoin_cli_json(cmd, *args):
     """
     Run `bitcoin-cli` using subprocess.check_output, parse output as JSON
     """
@@ -323,7 +323,7 @@ def require_minimum_bitcoind_version(min_version):
     Fail if the bitcoind version in use is older than required
     <min_version> - required minimum version in format of getnetworkinfo, i.e. 150100 for v0.15.1
     """
-    networkinfo = bitcoin_cli_json_nosplit("getnetworkinfo")
+    networkinfo = bitcoin_cli_json("getnetworkinfo")
 
     if int(networkinfo["version"]) < min_version:
         print "ERROR: Your bitcoind version is too old. You have {}, I need {} or newer. Exiting...".format(networkinfo["version"], min_version)
@@ -344,7 +344,7 @@ def get_address_for_wif_privkey(privkey):
 
     ensure_bitcoind_running()
     bitcoin_cli_call("importprivkey", privkey, label)
-    addresses = bitcoin_cli_json_nosplit("getaddressesbylabel", label)
+    addresses = bitcoin_cli_json("getaddressesbylabel", label)
 
     # getaddressesbylabel returns multiple addresses associated with
     # this one privkey; since we use it only for communicating the
@@ -363,7 +363,7 @@ def addmultisigaddress(m, addresses_or_pubkeys, address_type='p2sh-segwit'):
     addresses_or_pubkeys: List<string> either addresses or hex pubkeys for each of the N keys
     """
     address_string = json.dumps(addresses_or_pubkeys)
-    return bitcoin_cli_json_nosplit("addmultisigaddress", str(m), address_string, "", address_type)
+    return bitcoin_cli_json("addmultisigaddress", str(m), address_string, "", address_type)
 
 def get_utxos(tx, address):
     """
@@ -450,7 +450,7 @@ def sign_transaction(source_address, keys, redeem_script, unsigned_hex, input_tx
                 "redeemScript": redeem_script
             })
 
-    signed_tx = bitcoin_cli_json_nosplit(
+    signed_tx = bitcoin_cli_json(
         "signrawtransactionwithkey",
         unsigned_hex, json.dumps(keys), json.dumps(inputs))
     return signed_tx
@@ -487,7 +487,7 @@ def get_fee_interactive(source_address, keys, destinations, redeem_script, input
         signed_tx = sign_transaction(source_address, keys,
                                      redeem_script, unsigned_tx, input_txs)
 
-        decoded_tx = bitcoin_cli_json_nosplit("decoderawtransaction", signed_tx["hex"])
+        decoded_tx = bitcoin_cli_json("decoderawtransaction", signed_tx["hex"])
         size = decoded_tx["vsize"]
 
         fee = size * fee_basis_satoshis_per_byte
@@ -728,7 +728,7 @@ def withdraw_interactive():
             if os.path.isfile(hex_tx):
                 hex_tx = open(hex_tx).read().strip()
 
-            tx = bitcoin_cli_json_nosplit("decoderawtransaction", hex_tx)
+            tx = bitcoin_cli_json("decoderawtransaction", hex_tx)
             txs.append(tx)
             utxos += get_utxos(tx, source_address)
 

--- a/glacierscript.py
+++ b/glacierscript.py
@@ -119,7 +119,7 @@ def bitcoin_cli_call(cmd, args="", silent=False):
     return run_subprocess(subprocess.call, "bitcoin-cli", cmd, args, silent)
 
 
-def bitcoin_cli_checkoutput(cmd="", args=""):
+def bitcoin_cli_checkoutput(cmd, args):
     """
     Run `bitcoin-cli` using subprocess.check_output
     """

--- a/glacierscript.py
+++ b/glacierscript.py
@@ -40,6 +40,7 @@ from base58 import b58encode
 
 SATOSHI_PLACES = Decimal("0.00000001")
 
+verbose_mode = 0
 
 ################################################################################################
 #
@@ -385,6 +386,11 @@ def get_utxos(tx, address):
             utxos.append(output)
 
     return utxos
+
+
+def verbose(content):
+    if verbose_mode: print content
+
 
 def create_unsigned_transaction(source_address, destinations, redeem_script, input_txs):
     """

--- a/glacierscript.py
+++ b/glacierscript.py
@@ -90,18 +90,20 @@ def btc_to_satoshi(btc):
 #
 ################################################################################################
 
-def run_subprocess(sub_func, exe, cmd, args, silent):
+def run_subprocess(sub_func, exe, *args, **kwargs):
     """
     Run a subprocess (bitcoind or bitcoin-cli)
     Returns => return value of subprocess.call() or subprocess.check_output()
 
     sub_func: which of {subprocess.call, subprocess.check_output} to run
     exe: executable file name (e.g. bitcoin-cli)
-    cmd: subcommand (e.g. decodetransaction)
-    args: arguments to subcommand
-    silent: if True, redirect stdout & stderr to /dev/null
+    args: arguments to exe
+    kwargs:
+      silent: if True, redirect stdout & stderr to /dev/null
     """
-    full_cmd = "{0} {1} {2} {3}".format(exe, cli_args, cmd, args)
+    silent = kwargs.pop('silent', False)
+    if kwargs: raise TypeError('Unexpected **kwargs: %r' % kwargs)
+    full_cmd = "{0} {1} {2} {3}".format(exe, cli_args, *args)
     cmd_list = shlex.split(full_cmd)
     subprocess_args = {}
     devnull = None
@@ -118,7 +120,7 @@ def bitcoin_cli_call(cmd, args="", silent=False):
     """
     Run `bitcoin-cli` using subprocess.call
     """
-    return run_subprocess(subprocess.call, "bitcoin-cli", cmd, args, silent)
+    return run_subprocess(subprocess.call, "bitcoin-cli", cmd, args, silent=silent)
 
 
 def bitcoin_cli_checkoutput(cmd, args):
@@ -139,7 +141,7 @@ def bitcoind_call(args, silent=False):
     """
     Run `bitcoind` using subprocess.call
     """
-    return run_subprocess(subprocess.call, "bitcoind", "", args, silent)
+    return run_subprocess(subprocess.call, "bitcoind", "", args, silent=silent)
 
 
 ################################################################################################

--- a/glacierscript.py
+++ b/glacierscript.py
@@ -123,7 +123,7 @@ def bitcoin_cli_call(cmd, *args, **kwargs):
     """
     Run `bitcoin-cli` using subprocess.call
     """
-    return run_subprocess(subprocess.call, "bitcoin-cli", cmd, *args, **kwargs)
+    return run_subprocess_nosplit(subprocess.call, "bitcoin-cli", cmd, *args, **kwargs)
 
 
 def bitcoin_cli_checkoutput(cmd, *args):

--- a/glacierscript.py
+++ b/glacierscript.py
@@ -109,12 +109,12 @@ def run_subprocess(sub_func, exe, *args, **kwargs):
     if sub_func == subprocess.check_output: verbose_descrip = "output"
     if verbose_descrip is None: raise TypeError("Expected sub_func to be either call or check_output")
     cmd_list = [exe] + cli_args + list(args)
+    verbose("bitcoin cli call:\n  {0}\n".format(" ".join(pipes.quote(x) for x in cmd_list)))
     subprocess_args = {}
     devnull = None
     if silent:
         devnull = open("/dev/null")
         subprocess_args.update({ 'stdout': devnull, 'stderr': devnull })
-    verbose("bitcoin cli call:\n  {0}\n".format(" ".join(pipes.quote(x) for x in cmd_list)))
     cmd_output = sub_func(cmd_list, **subprocess_args)
     verbose("bitcoin cli call {0}:\n  {1}\n".format(verbose_descrip, cmd_output))
     if devnull:

--- a/glacierscript.py
+++ b/glacierscript.py
@@ -92,12 +92,11 @@ def btc_to_satoshi(btc):
 #
 ################################################################################################
 
-def run_subprocess(sub_func, exe, *args):
+def run_subprocess(exe, *args):
     """
     Run a subprocess (bitcoind or bitcoin-cli)
-    Returns => return value of subprocess.call() or subprocess.check_output()
+    Returns => (return code, output)
 
-    sub_func: which of {subprocess.call, subprocess.check_output} to run
     exe: executable file name (e.g. bitcoin-cli)
     args: arguments to exe
     """
@@ -115,32 +114,32 @@ def run_subprocess(sub_func, exe, *args):
 
 def bitcoin_cli_call(*args):
     """
-    Run `bitcoin-cli` using subprocess.call
+    Run `bitcoin-cli`, return OS return code
     """
-    retcode, _ = run_subprocess(subprocess.call, "bitcoin-cli", *args)
+    retcode, _ = run_subprocess("bitcoin-cli", *args)
     return retcode
 
 
 def bitcoin_cli_checkoutput(*args):
     """
-    Run `bitcoin-cli` using subprocess.check_output
+    Run `bitcoin-cli`, fail if OS return code nonzero, return output
     """
-    _, output = run_subprocess(subprocess.check_output, "bitcoin-cli", *args)
+    _, output = run_subprocess("bitcoin-cli", *args)
     return output
 
 
 def bitcoin_cli_json(*args):
     """
-    Run `bitcoin-cli` using subprocess.check_output, parse output as JSON
+    Run `bitcoin-cli`, parse output as JSON
     """
     return json.loads(bitcoin_cli_checkoutput(*args))
 
 
 def bitcoind_call(*args):
     """
-    Run `bitcoind` using subprocess.call
+    Run `bitcoind`, return OS return code
     """
-    retcode, _ = run_subprocess(subprocess.call, "bitcoind", *args)
+    retcode, _ = run_subprocess("bitcoind", *args)
     return retcode
 
 

--- a/glacierscript.py
+++ b/glacierscript.py
@@ -469,9 +469,9 @@ def sign_transaction(source_address, keys, redeem_script, unsigned_hex, input_tx
                 "redeemScript": redeem_script
             })
 
-    argstring_2 = "{0} '{1}' '{2}'".format(
+    signed_tx = bitcoin_cli_json_nosplit(
+        "signrawtransactionwithkey",
         unsigned_hex, json.dumps(keys), json.dumps(inputs))
-    signed_tx = bitcoin_cli_json("signrawtransactionwithkey", argstring_2)
     return signed_tx
 
 

--- a/glacierscript.py
+++ b/glacierscript.py
@@ -114,25 +114,25 @@ def run_subprocess(sub_func, exe, *args):
     return cmd_output
 
 
-def bitcoin_cli_call(cmd, *args):
+def bitcoin_cli_call(*args):
     """
     Run `bitcoin-cli` using subprocess.call
     """
-    return run_subprocess(subprocess.call, "bitcoin-cli", cmd, *args)
+    return run_subprocess(subprocess.call, "bitcoin-cli", *args)
 
 
-def bitcoin_cli_checkoutput(cmd, *args):
+def bitcoin_cli_checkoutput(*args):
     """
     Run `bitcoin-cli` using subprocess.check_output
     """
-    return run_subprocess(subprocess.check_output, "bitcoin-cli", cmd, *args)
+    return run_subprocess(subprocess.check_output, "bitcoin-cli", *args)
 
 
-def bitcoin_cli_json(cmd, *args):
+def bitcoin_cli_json(*args):
     """
     Run `bitcoin-cli` using subprocess.check_output, parse output as JSON
     """
-    return json.loads(bitcoin_cli_checkoutput(cmd, *args))
+    return json.loads(bitcoin_cli_checkoutput(*args))
 
 
 def bitcoind_call(*args):

--- a/glacierscript.py
+++ b/glacierscript.py
@@ -382,8 +382,7 @@ def addmultisigaddress(m, addresses_or_pubkeys, address_type='p2sh-segwit'):
     addresses_or_pubkeys: List<string> either addresses or hex pubkeys for each of the N keys
     """
     address_string = json.dumps(addresses_or_pubkeys)
-    argstring = "{0} '{1}' '' '{2}'".format(m, address_string, address_type)
-    return bitcoin_cli_json("addmultisigaddress", argstring)
+    return bitcoin_cli_json_nosplit("addmultisigaddress", str(m), address_string, "", address_type)
 
 def get_utxos(tx, address):
     """

--- a/glacierscript.py
+++ b/glacierscript.py
@@ -271,8 +271,7 @@ def require_minimum_bitcoind_version(min_version):
     Fail if the bitcoind version in use is older than required
     <min_version> - required minimum version in format of getnetworkinfo, i.e. 150100 for v0.15.1
     """
-    networkinfo_str = bitcoin_cli_checkoutput("getnetworkinfo")
-    networkinfo = json.loads(networkinfo_str)
+    networkinfo = json.loads(bitcoin_cli_checkoutput("getnetworkinfo"))
 
     if int(networkinfo["version"]) < min_version:
         print "ERROR: Your bitcoind version is too old. You have {}, I need {} or newer. Exiting...".format(networkinfo["version"], min_version)
@@ -293,11 +292,8 @@ def get_address_for_wif_privkey(privkey):
 
     ensure_bitcoind_running()
     bitcoin_cli_call("importprivkey", "{0} {1}".format(privkey, account_number))
-    addresses = bitcoin_cli_checkoutput("getaddressesbyaccount", account_number)
-
-    # extract address from JSON output
-    addresses_json = json.loads(addresses)
-    return addresses_json[0]
+    addresses = json.loads(bitcoin_cli_checkoutput("getaddressesbyaccount", account_number))
+    return addresses[0]
 
 
 def addmultisigaddress(m, addresses_or_pubkeys, address_type='p2sh-segwit'):
@@ -434,9 +430,7 @@ def sign_transaction(source_address, keys, redeem_script, unsigned_hex, input_tx
 
     argstring_2 = "{0} '{1}' '{2}'".format(
         unsigned_hex, json.dumps(inputs), json.dumps(keys))
-    signed_hex = bitcoin_cli_checkoutput("signrawtransaction", argstring_2).strip()
-
-    signed_tx = json.loads(signed_hex)
+    signed_tx = json.loads(bitcoin_cli_checkoutput("signrawtransaction", argstring_2).strip())
     return signed_tx
 
 

--- a/glacierscript.py
+++ b/glacierscript.py
@@ -90,7 +90,7 @@ def btc_to_satoshi(btc):
 #
 ################################################################################################
 
-def run_subprocess_nosplit(sub_func, exe, *args, **kwargs):
+def run_subprocess(sub_func, exe, *args, **kwargs):
     """
     Run a subprocess (bitcoind or bitcoin-cli)
     Returns => return value of subprocess.call() or subprocess.check_output()
@@ -119,14 +119,14 @@ def bitcoin_cli_call(cmd, *args, **kwargs):
     """
     Run `bitcoin-cli` using subprocess.call
     """
-    return run_subprocess_nosplit(subprocess.call, "bitcoin-cli", cmd, *args, **kwargs)
+    return run_subprocess(subprocess.call, "bitcoin-cli", cmd, *args, **kwargs)
 
 
 def bitcoin_cli_checkoutput_nosplit(cmd, *args):
     """
     Run `bitcoin-cli` using subprocess.check_output
     """
-    return run_subprocess_nosplit(subprocess.check_output, "bitcoin-cli", cmd, *args, silent=False)
+    return run_subprocess(subprocess.check_output, "bitcoin-cli", cmd, *args, silent=False)
 
 
 def bitcoin_cli_json_nosplit(cmd, *args):
@@ -140,7 +140,7 @@ def bitcoind_call(*args, **kwargs):
     """
     Run `bitcoind` using subprocess.call
     """
-    return run_subprocess_nosplit(subprocess.call, "bitcoind", *args, **kwargs)
+    return run_subprocess(subprocess.call, "bitcoind", *args, **kwargs)
 
 
 ################################################################################################

--- a/glacierscript.py
+++ b/glacierscript.py
@@ -430,7 +430,7 @@ def sign_transaction(source_address, keys, redeem_script, unsigned_hex, input_tx
 
     argstring_2 = "{0} '{1}' '{2}'".format(
         unsigned_hex, json.dumps(inputs), json.dumps(keys))
-    signed_tx = json.loads(bitcoin_cli_checkoutput("signrawtransaction", argstring_2).strip())
+    signed_tx = json.loads(bitcoin_cli_checkoutput("signrawtransaction", argstring_2))
     return signed_tx
 
 

--- a/glacierscript.py
+++ b/glacierscript.py
@@ -109,7 +109,9 @@ def run_subprocess(sub_func, exe, *args, **kwargs):
     if silent:
         devnull = open("/dev/null")
         subprocess_args.update({ 'stdout': devnull, 'stderr': devnull })
+    verbose("bitcoin cli call:\n  {0}\n".format(" ".join(cmd_list)))
     cmd_output = sub_func(cmd_list, **subprocess_args)
+    verbose("bitcoin cli call output:\n  {0}\n".format(cmd_output))
     if devnull:
         devnull.close()
     return cmd_output

--- a/glacierscript.py
+++ b/glacierscript.py
@@ -346,7 +346,7 @@ def get_address_for_wif_privkey(privkey):
     label = str(random.randint(0, 2**128))
 
     ensure_bitcoind_running()
-    bitcoin_cli_call("importprivkey", "{0} {1}".format(privkey, label))
+    bitcoin_cli_call("importprivkey", privkey, label)
     addresses = bitcoin_cli_json("getaddressesbylabel", label)
 
     # getaddressesbylabel returns multiple addresses associated with

--- a/glacierscript.py
+++ b/glacierscript.py
@@ -103,9 +103,8 @@ def run_subprocess(sub_func, exe, *args, **kwargs):
     """
     silent = kwargs.pop('silent', False)
     if kwargs: raise TypeError('Unexpected **kwargs: %r' % kwargs)
-    mylist = [exe] + cli_args + list(args)
-    full_cmd = " ".join(mylist)
-    cmd_list = shlex.split(full_cmd)
+    arglist = shlex.split(" ".join(list(args)))
+    cmd_list = [exe] + cli_args + arglist
     subprocess_args = {}
     devnull = None
     if silent:

--- a/glacierscript.py
+++ b/glacierscript.py
@@ -335,7 +335,7 @@ def get_utxos(tx, address):
 
     return utxos
 
-def run_subprocess(sub_func, exe, cmd, args, silent=False, **optargs):
+def run_subprocess(sub_func, exe, cmd, args, silent=False):
     """
     Run a subprocess (bitcoind or bitcoin-cli)
     Returns => return value of subprocess.call() or subprocess.check_output()

--- a/glacierscript.py
+++ b/glacierscript.py
@@ -100,9 +100,7 @@ def run_subprocess(sub_func, exe, cmd, args, silent):
     args: arguments to subcommand
     silent: if True, redirect stdout & stderr to /dev/null
     """
-    if cmd is not "": cmd = " {0}".format(cmd)
-    if args is not "": args = " {0}".format(args)
-    full_cmd = "{0}{1}{2}".format(exe, cmd, args)
+    full_cmd = "{0} {1} {2}".format(exe, cmd, args)
     subprocess_args = { 'shell': True }
     devnull = None
     if silent:

--- a/glacierscript.py
+++ b/glacierscript.py
@@ -133,6 +133,13 @@ def bitcoin_cli_checkoutput(cmd, *args):
     return run_subprocess(subprocess.check_output, "bitcoin-cli", cmd, *args, silent=False)
 
 
+def bitcoin_cli_checkoutput_nosplit(cmd, *args):
+    """
+    Run `bitcoin-cli` using subprocess.check_output
+    """
+    return run_subprocess_nosplit(subprocess.check_output, "bitcoin-cli", cmd, *args, silent=False)
+
+
 def bitcoin_cli_json(cmd, args=""):
     """
     Run `bitcoin-cli` using subprocess.check_output, parse output as JSON
@@ -421,10 +428,10 @@ def create_unsigned_transaction(source_address, destinations, redeem_script, inp
                 "vout": int(utxo["n"])
             })
 
-    argstring = "'{0}' '{1}'".format(
-        json.dumps(inputs), json.dumps(destinations))
-
-    tx_unsigned_hex = bitcoin_cli_checkoutput("createrawtransaction", argstring).strip()
+    tx_unsigned_hex = bitcoin_cli_checkoutput_nosplit(
+        "createrawtransaction",
+        json.dumps(inputs),
+        json.dumps(destinations)).strip()
 
     return tx_unsigned_hex
 

--- a/glacierscript.py
+++ b/glacierscript.py
@@ -90,10 +90,6 @@ def btc_to_satoshi(btc):
 #
 ################################################################################################
 
-def run_subprocess(sub_func, exe, *args, **kwargs):
-    arglist = shlex.split(" ".join(list(args)))
-    return run_subprocess_nosplit(sub_func, exe, *arglist, **kwargs)
-
 def run_subprocess_nosplit(sub_func, exe, *args, **kwargs):
     """
     Run a subprocess (bitcoind or bitcoin-cli)
@@ -126,25 +122,11 @@ def bitcoin_cli_call(cmd, *args, **kwargs):
     return run_subprocess_nosplit(subprocess.call, "bitcoin-cli", cmd, *args, **kwargs)
 
 
-def bitcoin_cli_checkoutput(cmd, *args):
-    """
-    Run `bitcoin-cli` using subprocess.check_output
-    """
-    return run_subprocess(subprocess.check_output, "bitcoin-cli", cmd, *args, silent=False)
-
-
 def bitcoin_cli_checkoutput_nosplit(cmd, *args):
     """
     Run `bitcoin-cli` using subprocess.check_output
     """
     return run_subprocess_nosplit(subprocess.check_output, "bitcoin-cli", cmd, *args, silent=False)
-
-
-def bitcoin_cli_json(cmd, args=""):
-    """
-    Run `bitcoin-cli` using subprocess.check_output, parse output as JSON
-    """
-    return json.loads(bitcoin_cli_checkoutput(cmd, args))
 
 
 def bitcoin_cli_json_nosplit(cmd, *args):

--- a/glacierscript.py
+++ b/glacierscript.py
@@ -91,6 +91,10 @@ def btc_to_satoshi(btc):
 ################################################################################################
 
 def run_subprocess(sub_func, exe, *args, **kwargs):
+    arglist = shlex.split(" ".join(list(args)))
+    return run_subprocess_nosplit(sub_func, exe, *arglist, **kwargs)
+
+def run_subprocess_nosplit(sub_func, exe, *args, **kwargs):
     """
     Run a subprocess (bitcoind or bitcoin-cli)
     Returns => return value of subprocess.call() or subprocess.check_output()
@@ -103,8 +107,7 @@ def run_subprocess(sub_func, exe, *args, **kwargs):
     """
     silent = kwargs.pop('silent', False)
     if kwargs: raise TypeError('Unexpected **kwargs: %r' % kwargs)
-    arglist = shlex.split(" ".join(list(args)))
-    cmd_list = [exe] + cli_args + arglist
+    cmd_list = [exe] + cli_args + list(args)
     subprocess_args = {}
     devnull = None
     if silent:

--- a/glacierscript.py
+++ b/glacierscript.py
@@ -112,7 +112,7 @@ def run_subprocess(sub_func, exe, cmd, args, silent):
     return cmd_output
 
 
-def bitcoin_cli_call(cmd="", args="", silent=False):
+def bitcoin_cli_call(cmd, args="", silent=False):
     """
     Run `bitcoin-cli` using subprocess.call
     """

--- a/glacierscript.py
+++ b/glacierscript.py
@@ -124,11 +124,11 @@ def bitcoin_cli_call(cmd, *args, **kwargs):
     return run_subprocess(subprocess.call, "bitcoin-cli", cmd, *args, **kwargs)
 
 
-def bitcoin_cli_checkoutput(cmd, args):
+def bitcoin_cli_checkoutput(cmd, *args):
     """
     Run `bitcoin-cli` using subprocess.check_output
     """
-    return run_subprocess(subprocess.check_output, "bitcoin-cli", cmd, args, silent=False)
+    return run_subprocess(subprocess.check_output, "bitcoin-cli", cmd, *args, silent=False)
 
 
 def bitcoin_cli_json(cmd, args=""):

--- a/glacierscript.py
+++ b/glacierscript.py
@@ -144,7 +144,7 @@ def bitcoind_call(*args, **kwargs):
     """
     Run `bitcoind` using subprocess.call
     """
-    return run_subprocess(subprocess.call, "bitcoind", *args, **kwargs)
+    return run_subprocess_nosplit(subprocess.call, "bitcoind", *args, **kwargs)
 
 
 ################################################################################################

--- a/glacierscript.py
+++ b/glacierscript.py
@@ -109,23 +109,24 @@ def run_subprocess(sub_func, exe, *args):
         for line in iter(pipe.stdout.readline, b''):
             output.write(line)
     retcode = pipe.wait()
-    cmd_output = retcode if sub_func == subprocess.call else output.getvalue()
     verbose("bitcoin cli call return code: {0}  output:\n  {1}\n".format(retcode, output.getvalue()))
-    return cmd_output
+    return (retcode, output.getvalue())
 
 
 def bitcoin_cli_call(*args):
     """
     Run `bitcoin-cli` using subprocess.call
     """
-    return run_subprocess(subprocess.call, "bitcoin-cli", *args)
+    retcode, _ = run_subprocess(subprocess.call, "bitcoin-cli", *args)
+    return retcode
 
 
 def bitcoin_cli_checkoutput(*args):
     """
     Run `bitcoin-cli` using subprocess.check_output
     """
-    return run_subprocess(subprocess.check_output, "bitcoin-cli", *args)
+    _, output = run_subprocess(subprocess.check_output, "bitcoin-cli", *args)
+    return output
 
 
 def bitcoin_cli_json(*args):
@@ -139,7 +140,8 @@ def bitcoind_call(*args):
     """
     Run `bitcoind` using subprocess.call
     """
-    return run_subprocess(subprocess.call, "bitcoind", *args)
+    retcode, _ = run_subprocess(subprocess.call, "bitcoind", *args)
+    return retcode
 
 
 ################################################################################################

--- a/glacierscript.py
+++ b/glacierscript.py
@@ -34,7 +34,6 @@ import random
 import subprocess
 import json
 from decimal import Decimal
-import shlex
 
 # Taken from Gavin Andresen's "bitcointools" python library (exact link in source file)
 from base58 import b58encode

--- a/glacierscript.py
+++ b/glacierscript.py
@@ -128,11 +128,11 @@ def bitcoin_cli_checkoutput(cmd="", args="", silent=False):
     return run_subprocess(subprocess.check_output, bitcoin_cli, cmd, args, silent)
 
 
-def bitcoin_cli_json(cmd="", args="", silent=False):
+def bitcoin_cli_json(cmd="", args=""):
     """
     Run `bitcoin-cli` using subprocess.check_output, parse output as JSON
     """
-    return json.loads(bitcoin_cli_checkoutput(cmd, args, silent))
+    return json.loads(bitcoin_cli_checkoutput(cmd, args, silent=False))
 
 
 def bitcoind_call(args="", silent=False):

--- a/glacierscript.py
+++ b/glacierscript.py
@@ -34,6 +34,7 @@ import random
 import subprocess
 import json
 from decimal import Decimal
+import shlex
 
 # Taken from Gavin Andresen's "bitcointools" python library (exact link in source file)
 from base58 import b58encode
@@ -101,12 +102,13 @@ def run_subprocess(sub_func, exe, cmd, args, silent):
     silent: if True, redirect stdout & stderr to /dev/null
     """
     full_cmd = "{0} {1} {2} {3}".format(exe, cli_args, cmd, args)
-    subprocess_args = { 'shell': True }
+    cmd_list = shlex.split(full_cmd)
+    subprocess_args = {}
     devnull = None
     if silent:
         devnull = open("/dev/null")
         subprocess_args.update({ 'stdout': devnull, 'stderr': devnull })
-    cmd_output = sub_func(full_cmd, **subprocess_args)
+    cmd_output = sub_func(cmd_list, **subprocess_args)
     if devnull:
         devnull.close()
     return cmd_output

--- a/glacierscript.py
+++ b/glacierscript.py
@@ -147,6 +147,13 @@ def bitcoin_cli_json(cmd, args=""):
     return json.loads(bitcoin_cli_checkoutput(cmd, args))
 
 
+def bitcoin_cli_json_nosplit(cmd, *args):
+    """
+    Run `bitcoin-cli` using subprocess.check_output, parse output as JSON
+    """
+    return json.loads(bitcoin_cli_checkoutput_nosplit(cmd, *args))
+
+
 def bitcoind_call(*args, **kwargs):
     """
     Run `bitcoind` using subprocess.call
@@ -335,7 +342,7 @@ def require_minimum_bitcoind_version(min_version):
     Fail if the bitcoind version in use is older than required
     <min_version> - required minimum version in format of getnetworkinfo, i.e. 150100 for v0.15.1
     """
-    networkinfo = bitcoin_cli_json("getnetworkinfo")
+    networkinfo = bitcoin_cli_json_nosplit("getnetworkinfo")
 
     if int(networkinfo["version"]) < min_version:
         print "ERROR: Your bitcoind version is too old. You have {}, I need {} or newer. Exiting...".format(networkinfo["version"], min_version)

--- a/glacierscript.py
+++ b/glacierscript.py
@@ -103,7 +103,8 @@ def run_subprocess(sub_func, exe, *args, **kwargs):
     """
     silent = kwargs.pop('silent', False)
     if kwargs: raise TypeError('Unexpected **kwargs: %r' % kwargs)
-    full_cmd = "{0} {1} {2} {3}".format(exe, cli_args, *args)
+    mylist = [exe, cli_args] + list(args)
+    full_cmd = " ".join(mylist)
     cmd_list = shlex.split(full_cmd)
     subprocess_args = {}
     devnull = None

--- a/glacierscript.py
+++ b/glacierscript.py
@@ -103,6 +103,10 @@ def run_subprocess(sub_func, exe, *args, **kwargs):
     """
     silent = kwargs.pop('silent', False)
     if kwargs: raise TypeError('Unexpected **kwargs: %r' % kwargs)
+    verbose_descrip = None
+    if sub_func == subprocess.call: verbose_descrip = "return code"
+    if sub_func == subprocess.check_output: verbose_descrip = "output"
+    if verbose_descrip is None: raise TypeError("Expected sub_func to be either call or check_output")
     cmd_list = [exe] + cli_args + list(args)
     subprocess_args = {}
     devnull = None
@@ -111,7 +115,7 @@ def run_subprocess(sub_func, exe, *args, **kwargs):
         subprocess_args.update({ 'stdout': devnull, 'stderr': devnull })
     verbose("bitcoin cli call:\n  {0}\n".format(" ".join(cmd_list)))
     cmd_output = sub_func(cmd_list, **subprocess_args)
-    verbose("bitcoin cli call output:\n  {0}\n".format(cmd_output))
+    verbose("bitcoin cli call {0}:\n  {1}\n".format(verbose_descrip, cmd_output))
     if devnull:
         devnull.close()
     return cmd_output

--- a/glacierscript.py
+++ b/glacierscript.py
@@ -95,7 +95,7 @@ def btc_to_satoshi(btc):
 def run_subprocess(exe, *args):
     """
     Run a subprocess (bitcoind or bitcoin-cli)
-    Returns => (return code, output)
+    Returns => (command, return code, output)
 
     exe: executable file name (e.g. bitcoin-cli)
     args: arguments to exe
@@ -109,14 +109,14 @@ def run_subprocess(exe, *args):
             output.write(line)
     retcode = pipe.wait()
     verbose("bitcoin cli call return code: {0}  output:\n  {1}\n".format(retcode, output.getvalue()))
-    return (retcode, output.getvalue())
+    return (cmd_list, retcode, output.getvalue())
 
 
 def bitcoin_cli_call(*args):
     """
     Run `bitcoin-cli`, return OS return code
     """
-    retcode, _ = run_subprocess("bitcoin-cli", *args)
+    _, retcode, _ = run_subprocess("bitcoin-cli", *args)
     return retcode
 
 
@@ -124,7 +124,8 @@ def bitcoin_cli_checkoutput(*args):
     """
     Run `bitcoin-cli`, fail if OS return code nonzero, return output
     """
-    _, output = run_subprocess("bitcoin-cli", *args)
+    cmd_list, retcode, output = run_subprocess("bitcoin-cli", *args)
+    if retcode != 0: raise subprocess.CalledProcessError(retcode, cmd_list, output=output)
     return output
 
 
@@ -139,7 +140,7 @@ def bitcoind_call(*args):
     """
     Run `bitcoind`, return OS return code
     """
-    retcode, _ = run_subprocess("bitcoind", *args)
+    _, retcode, _ = run_subprocess("bitcoind", *args)
     return retcode
 
 

--- a/glacierscript.py
+++ b/glacierscript.py
@@ -91,6 +91,10 @@ def btc_to_satoshi(btc):
 #
 ################################################################################################
 
+def verbose(content):
+    if verbose_mode: print content
+
+
 def run_subprocess(exe, *args):
     """
     Run a subprocess (bitcoind or bitcoin-cli)
@@ -383,10 +387,6 @@ def get_utxos(tx, address):
             utxos.append(output)
 
     return utxos
-
-
-def verbose(content):
-    if verbose_mode: print content
 
 
 def create_unsigned_transaction(source_address, destinations, redeem_script, input_txs):

--- a/glacierscript.py
+++ b/glacierscript.py
@@ -860,7 +860,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "-n", type=int, help="Number of total keys required in an m-of-n multisig address creation (default m-of-n = 1-of-2)", default=2)
     parser.add_argument('--testnet', type=int, help=argparse.SUPPRESS)
-    parser.add_argument('-v', action='store_true', dest='verbose_mode', help='increase output verbosity')
+    parser.add_argument('-v', '--verbose', action='store_true', dest='verbose_mode', help='increase output verbosity')
     args = parser.parse_args()
 
     verbose_mode = args.verbose_mode

--- a/glacierscript.py
+++ b/glacierscript.py
@@ -860,10 +860,10 @@ if __name__ == "__main__":
     parser.add_argument(
         "-n", type=int, help="Number of total keys required in an m-of-n multisig address creation (default m-of-n = 1-of-2)", default=2)
     parser.add_argument('--testnet', type=int, help=argparse.SUPPRESS)
-    parser.add_argument('-v', '--verbose', action='store_true', dest='verbose_mode', help='increase output verbosity')
+    parser.add_argument('-v', '--verbose', action='store_true', help='increase output verbosity')
     args = parser.parse_args()
 
-    verbose_mode = args.verbose_mode
+    verbose_mode = args.verbose
 
     global cli_args, wif_prefix
     cli_args = ["-testnet", "-rpcport={}".format(args.testnet), "-datadir=bitcoin-test-data"] if args.testnet else []

--- a/glacierscript.py
+++ b/glacierscript.py
@@ -92,7 +92,7 @@ def btc_to_satoshi(btc):
 ################################################################################################
 
 def verbose(content):
-    if verbose_mode: print content
+    if verbose_mode: print(content)
 
 
 def run_subprocess(exe, *args):

--- a/glacierscript.py
+++ b/glacierscript.py
@@ -117,11 +117,11 @@ def run_subprocess(sub_func, exe, *args, **kwargs):
     return cmd_output
 
 
-def bitcoin_cli_call(cmd, args="", silent=False):
+def bitcoin_cli_call(cmd, *args, **kwargs):
     """
     Run `bitcoin-cli` using subprocess.call
     """
-    return run_subprocess(subprocess.call, "bitcoin-cli", cmd, args, silent=silent)
+    return run_subprocess(subprocess.call, "bitcoin-cli", cmd, *args, **kwargs)
 
 
 def bitcoin_cli_checkoutput(cmd, args):

--- a/glacierscript.py
+++ b/glacierscript.py
@@ -89,7 +89,7 @@ def btc_to_satoshi(btc):
 #
 ################################################################################################
 
-def run_subprocess(sub_func, exe, cmd, args, silent=False):
+def run_subprocess(sub_func, exe, cmd, args, silent):
     """
     Run a subprocess (bitcoind or bitcoin-cli)
     Returns => return value of subprocess.call() or subprocess.check_output()
@@ -114,32 +114,32 @@ def run_subprocess(sub_func, exe, cmd, args, silent=False):
     return cmd_output
 
 
-def bitcoin_cli_call(cmd="", args="", **optargs):
+def bitcoin_cli_call(cmd="", args="", silent=False):
     """
     Run `bitcoin-cli` using subprocess.call
     """
-    return run_subprocess(subprocess.call, bitcoin_cli, cmd, args, **optargs)
+    return run_subprocess(subprocess.call, bitcoin_cli, cmd, args, silent)
 
 
-def bitcoin_cli_checkoutput(cmd="", args="", **optargs):
+def bitcoin_cli_checkoutput(cmd="", args="", silent=False):
     """
     Run `bitcoin-cli` using subprocess.check_output
     """
-    return run_subprocess(subprocess.check_output, bitcoin_cli, cmd, args, **optargs)
+    return run_subprocess(subprocess.check_output, bitcoin_cli, cmd, args, silent)
 
 
-def bitcoin_cli_json(cmd="", args="", **optargs):
+def bitcoin_cli_json(cmd="", args="", silent=False):
     """
     Run `bitcoin-cli` using subprocess.check_output, parse output as JSON
     """
-    return json.loads(bitcoin_cli_checkoutput(cmd, args, **optargs))
+    return json.loads(bitcoin_cli_checkoutput(cmd, args, silent))
 
 
-def bitcoind_call(args="", **optargs):
+def bitcoind_call(args="", silent=False):
     """
     Run `bitcoind` using subprocess.call
     """
-    return run_subprocess(subprocess.call, bitcoind, "", args, **optargs)
+    return run_subprocess(subprocess.call, bitcoind, "", args, silent)
 
 
 ################################################################################################

--- a/glacierscript.py
+++ b/glacierscript.py
@@ -138,11 +138,11 @@ def bitcoin_cli_json(cmd, args=""):
     return json.loads(bitcoin_cli_checkoutput(cmd, args))
 
 
-def bitcoind_call(args, silent=False):
+def bitcoind_call(*args, **kwargs):
     """
     Run `bitcoind` using subprocess.call
     """
-    return run_subprocess(subprocess.call, "bitcoind", "", args, silent=silent)
+    return run_subprocess(subprocess.call, "bitcoind", *args, **kwargs)
 
 
 ################################################################################################
@@ -309,7 +309,7 @@ def ensure_bitcoind_running():
     # message (to /dev/null) and exit.
     #
     # -connect=0.0.0.0 because we're doing local operations only (and have no network connection anyway)
-    bitcoind_call("-daemon -connect=0.0.0.0", silent=True)
+    bitcoind_call("-daemon", "-connect=0.0.0.0", silent=True)
 
     # verify bitcoind started up and is functioning correctly
     times = 0

--- a/glacierscript.py
+++ b/glacierscript.py
@@ -121,7 +121,7 @@ def bitcoin_cli_call(cmd, *args, **kwargs):
     return run_subprocess(subprocess.call, "bitcoin-cli", cmd, *args, **kwargs)
 
 
-def bitcoin_cli_checkoutput_nosplit(cmd, *args):
+def bitcoin_cli_checkoutput(cmd, *args):
     """
     Run `bitcoin-cli` using subprocess.check_output
     """
@@ -132,7 +132,7 @@ def bitcoin_cli_json_nosplit(cmd, *args):
     """
     Run `bitcoin-cli` using subprocess.check_output, parse output as JSON
     """
-    return json.loads(bitcoin_cli_checkoutput_nosplit(cmd, *args))
+    return json.loads(bitcoin_cli_checkoutput(cmd, *args))
 
 
 def bitcoind_call(*args, **kwargs):
@@ -415,7 +415,7 @@ def create_unsigned_transaction(source_address, destinations, redeem_script, inp
                 "vout": int(utxo["n"])
             })
 
-    tx_unsigned_hex = bitcoin_cli_checkoutput_nosplit(
+    tx_unsigned_hex = bitcoin_cli_checkoutput(
         "createrawtransaction",
         json.dumps(inputs),
         json.dumps(destinations)).strip()

--- a/glacierscript.py
+++ b/glacierscript.py
@@ -747,7 +747,7 @@ def withdraw_interactive():
             if os.path.isfile(hex_tx):
                 hex_tx = open(hex_tx).read().strip()
 
-            tx = bitcoin_cli_json("decoderawtransaction", hex_tx)
+            tx = bitcoin_cli_json_nosplit("decoderawtransaction", hex_tx)
             txs.append(tx)
             utxos += get_utxos(tx, source_address)
 

--- a/glacierscript.py
+++ b/glacierscript.py
@@ -100,7 +100,7 @@ def run_subprocess(sub_func, exe, cmd, args, silent):
     args: arguments to subcommand
     silent: if True, redirect stdout & stderr to /dev/null
     """
-    full_cmd = "{0} {1} {2}".format(exe, cmd, args)
+    full_cmd = "{0} {1} {2} {3}".format(exe, cli_args, cmd, args)
     subprocess_args = { 'shell': True }
     devnull = None
     if silent:
@@ -116,14 +116,14 @@ def bitcoin_cli_call(cmd="", args="", silent=False):
     """
     Run `bitcoin-cli` using subprocess.call
     """
-    return run_subprocess(subprocess.call, bitcoin_cli, cmd, args, silent)
+    return run_subprocess(subprocess.call, "bitcoin-cli", cmd, args, silent)
 
 
 def bitcoin_cli_checkoutput(cmd="", args=""):
     """
     Run `bitcoin-cli` using subprocess.check_output
     """
-    return run_subprocess(subprocess.check_output, bitcoin_cli, cmd, args, silent=False)
+    return run_subprocess(subprocess.check_output, "bitcoin-cli", cmd, args, silent=False)
 
 
 def bitcoin_cli_json(cmd="", args=""):
@@ -137,7 +137,7 @@ def bitcoind_call(args="", silent=False):
     """
     Run `bitcoind` using subprocess.call
     """
-    return run_subprocess(subprocess.call, bitcoind, "", args, silent)
+    return run_subprocess(subprocess.call, "bitcoind", "", args, silent)
 
 
 ################################################################################################
@@ -860,11 +860,9 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
 
-    global bitcoind, bitcoin_cli, wif_prefix
-    cli_args = "-testnet -rpcport={} -datadir=bitcoin-test-data ".format(args.testnet) if args.testnet else ""
+    global cli_args, wif_prefix
+    cli_args = "-testnet -rpcport={} -datadir=bitcoin-test-data".format(args.testnet) if args.testnet else ""
     wif_prefix = "EF" if args.testnet else "80"
-    bitcoind = "bitcoind " + cli_args
-    bitcoin_cli = "bitcoin-cli " + cli_args
 
     if args.program == "entropy":
         entropy(args.num_keys, args.rng)

--- a/glacierscript.py
+++ b/glacierscript.py
@@ -92,7 +92,7 @@ def btc_to_satoshi(btc):
 #
 ################################################################################################
 
-def run_subprocess(sub_func, exe, *args, **kwargs):
+def run_subprocess(sub_func, exe, *args):
     """
     Run a subprocess (bitcoind or bitcoin-cli)
     Returns => return value of subprocess.call() or subprocess.check_output()
@@ -100,10 +100,7 @@ def run_subprocess(sub_func, exe, *args, **kwargs):
     sub_func: which of {subprocess.call, subprocess.check_output} to run
     exe: executable file name (e.g. bitcoin-cli)
     args: arguments to exe
-    kwargs:
-      none, should be removed
     """
-    if kwargs: raise TypeError('Unexpected **kwargs: %r' % kwargs)
     cmd_list = [exe] + cli_args + list(args)
     verbose("bitcoin cli call:\n  {0}\n".format(" ".join(pipes.quote(x) for x in cmd_list)))
     output = StringIO.StringIO()
@@ -117,11 +114,11 @@ def run_subprocess(sub_func, exe, *args, **kwargs):
     return cmd_output
 
 
-def bitcoin_cli_call(cmd, *args, **kwargs):
+def bitcoin_cli_call(cmd, *args):
     """
     Run `bitcoin-cli` using subprocess.call
     """
-    return run_subprocess(subprocess.call, "bitcoin-cli", cmd, *args, **kwargs)
+    return run_subprocess(subprocess.call, "bitcoin-cli", cmd, *args)
 
 
 def bitcoin_cli_checkoutput(cmd, *args):
@@ -138,11 +135,11 @@ def bitcoin_cli_json(cmd, *args):
     return json.loads(bitcoin_cli_checkoutput(cmd, *args))
 
 
-def bitcoind_call(*args, **kwargs):
+def bitcoind_call(*args):
     """
     Run `bitcoind` using subprocess.call
     """
-    return run_subprocess(subprocess.call, "bitcoind", *args, **kwargs)
+    return run_subprocess(subprocess.call, "bitcoind", *args)
 
 
 ################################################################################################

--- a/glacierscript.py
+++ b/glacierscript.py
@@ -121,18 +121,18 @@ def bitcoin_cli_call(cmd="", args="", silent=False):
     return run_subprocess(subprocess.call, bitcoin_cli, cmd, args, silent)
 
 
-def bitcoin_cli_checkoutput(cmd="", args="", silent=False):
+def bitcoin_cli_checkoutput(cmd="", args=""):
     """
     Run `bitcoin-cli` using subprocess.check_output
     """
-    return run_subprocess(subprocess.check_output, bitcoin_cli, cmd, args, silent)
+    return run_subprocess(subprocess.check_output, bitcoin_cli, cmd, args, silent=False)
 
 
 def bitcoin_cli_json(cmd="", args=""):
     """
     Run `bitcoin-cli` using subprocess.check_output, parse output as JSON
     """
-    return json.loads(bitcoin_cli_checkoutput(cmd, args, silent=False))
+    return json.loads(bitcoin_cli_checkoutput(cmd, args))
 
 
 def bitcoind_call(args="", silent=False):

--- a/glacierscript.py
+++ b/glacierscript.py
@@ -105,10 +105,6 @@ def run_subprocess(sub_func, exe, *args, **kwargs):
     """
     silent = kwargs.pop('silent', False)
     if kwargs: raise TypeError('Unexpected **kwargs: %r' % kwargs)
-    verbose_descrip = None
-    if sub_func == subprocess.call: verbose_descrip = "return code"
-    if sub_func == subprocess.check_output: verbose_descrip = "output"
-    if verbose_descrip is None: raise TypeError("Expected sub_func to be either call or check_output")
     cmd_list = [exe] + cli_args + list(args)
     verbose("bitcoin cli call:\n  {0}\n".format(" ".join(pipes.quote(x) for x in cmd_list)))
     output = StringIO.StringIO()
@@ -118,7 +114,7 @@ def run_subprocess(sub_func, exe, *args, **kwargs):
             output.write(line)
     retcode = pipe.wait()
     cmd_output = retcode if sub_func == subprocess.call else output.getvalue()
-    verbose("bitcoin cli call {0}:\n  {1}\n".format(verbose_descrip, cmd_output))
+    verbose("bitcoin cli call return code: {0}  output:\n  {1}\n".format(retcode, output.getvalue()))
     return cmd_output
 
 

--- a/glacierscript.py
+++ b/glacierscript.py
@@ -101,9 +101,8 @@ def run_subprocess(sub_func, exe, *args, **kwargs):
     exe: executable file name (e.g. bitcoin-cli)
     args: arguments to exe
     kwargs:
-      silent: if True, redirect stdout & stderr to /dev/null
+      none, should be removed
     """
-    silent = kwargs.pop('silent', False)
     if kwargs: raise TypeError('Unexpected **kwargs: %r' % kwargs)
     cmd_list = [exe] + cli_args + list(args)
     verbose("bitcoin cli call:\n  {0}\n".format(" ".join(pipes.quote(x) for x in cmd_list)))
@@ -129,7 +128,7 @@ def bitcoin_cli_checkoutput(cmd, *args):
     """
     Run `bitcoin-cli` using subprocess.check_output
     """
-    return run_subprocess(subprocess.check_output, "bitcoin-cli", cmd, *args, silent=False)
+    return run_subprocess(subprocess.check_output, "bitcoin-cli", cmd, *args)
 
 
 def bitcoin_cli_json(cmd, *args):
@@ -310,13 +309,13 @@ def ensure_bitcoind_running():
     # message (to /dev/null) and exit.
     #
     # -connect=0.0.0.0 because we're doing local operations only (and have no network connection anyway)
-    bitcoind_call("-daemon", "-connect=0.0.0.0", silent=True)
+    bitcoind_call("-daemon", "-connect=0.0.0.0")
 
     # verify bitcoind started up and is functioning correctly
     times = 0
     while times <= 20:
         times += 1
-        if bitcoin_cli_call("getnetworkinfo", silent=True) == 0:
+        if bitcoin_cli_call("getnetworkinfo") == 0:
             return
         time.sleep(0.5)
 

--- a/t/create-withdrawal-data.fails.decoded
+++ b/t/create-withdrawal-data.fails.decoded
@@ -1,0 +1,1 @@
+No transaction found

--- a/t/create-withdrawal-data.fails.golden
+++ b/t/create-withdrawal-data.fails.golden
@@ -21,14 +21,14 @@ How many private keys will you be signing this transaction with?
 #: Key #1: Key #2: 
 Enter fee rate.
 Satoshis per vbyte: Traceback (most recent call last):
-  File "../../glacierscript.py", line 884, in <module>
+  File "../../glacierscript.py", line 880, in <module>
     withdraw_interactive()
-  File "../../glacierscript.py", line 766, in withdraw_interactive
+  File "../../glacierscript.py", line 762, in withdraw_interactive
     source_address, keys, addresses, redeem_script, txs)
-  File "../../glacierscript.py", line 492, in get_fee_interactive
+  File "../../glacierscript.py", line 488, in get_fee_interactive
     source_address, destinations, redeem_script, input_txs)
-  File "../../glacierscript.py", line 428, in create_unsigned_transaction
+  File "../../glacierscript.py", line 424, in create_unsigned_transaction
     json.dumps(destinations)).strip()
-  File "../../glacierscript.py", line 128, in bitcoin_cli_checkoutput
+  File "../../glacierscript.py", line 124, in bitcoin_cli_checkoutput
     if retcode != 0: raise subprocess.CalledProcessError(retcode, cmd_list, output=output)
 subprocess.CalledProcessError: Command '['bitcoin-cli', '-testnet', '-rpcport=18340', '-datadir=bitcoin-test-data', 'createrawtransaction', '[{"vout": 1, "txid": "e0e9bb25fb873c4caccdc8ab743c4350310031f2cc077bb90c3f495458860157"}]', '{"2N93du8YobdgsHyu3qgBvSyhGUT52utMNeA": 0, "myP4xdJNwAW9iMakvCjnozg814ewgn8apx": 0}']' returned non-zero exit status 5

--- a/t/create-withdrawal-data.fails.golden
+++ b/t/create-withdrawal-data.fails.golden
@@ -1,0 +1,34 @@
+Are you running this on a computer WITHOUT a network connection of any kind? (y/n)?Have the wireless cards in this computer been physically removed? (y/n)?Are you running on battery power? (y/n)?Are you running on an operating system booted from a USB drive? (y/n)?Is your screen hidden from view of windows, cameras, and other people? (y/n)?Are smartphones and all other nearby devices turned off and in a Faraday bag? (y/n)?
+You will need to enter several pieces of information to create a withdrawal transaction.
+
+
+*** PLEASE BE SURE TO ENTER THE CORRECT DESTINATION ADDRESS ***
+
+
+Source cold storage address: 
+Redemption script for source cold storage address: 
+Destination address: 
+How many unspent transactions will you be using for this withdrawal? 
+Please paste raw transaction #1 (hexadecimal format) with unspent outputs at the source address
+OR
+input a filename located in the current directory which contains the raw transaction data
+(If the transaction data is over ~4000 characters long, you _must_ use a file.):
+
+Transaction data found for source address.
+TOTAL unspent amount for this raw transaction: 0.10000000 BTC
+
+How many private keys will you be signing this transaction with? 
+#: Key #1: Key #2: 
+Enter fee rate.
+Satoshis per vbyte: Traceback (most recent call last):
+  File "../../glacierscript.py", line 884, in <module>
+    withdraw_interactive()
+  File "../../glacierscript.py", line 766, in withdraw_interactive
+    source_address, keys, addresses, redeem_script, txs)
+  File "../../glacierscript.py", line 492, in get_fee_interactive
+    source_address, destinations, redeem_script, input_txs)
+  File "../../glacierscript.py", line 428, in create_unsigned_transaction
+    json.dumps(destinations)).strip()
+  File "../../glacierscript.py", line 128, in bitcoin_cli_checkoutput
+    if retcode != 0: raise subprocess.CalledProcessError(retcode, cmd_list, output=output)
+subprocess.CalledProcessError: Command '['bitcoin-cli', '-testnet', '-rpcport=18340', '-datadir=bitcoin-test-data', 'createrawtransaction', '[{"vout": 1, "txid": "e0e9bb25fb873c4caccdc8ab743c4350310031f2cc077bb90c3f495458860157"}]', '{"2N93du8YobdgsHyu3qgBvSyhGUT52utMNeA": 0, "myP4xdJNwAW9iMakvCjnozg814ewgn8apx": 0}']' returned non-zero exit status 5

--- a/t/create-withdrawal-data.fails.golden
+++ b/t/create-withdrawal-data.fails.golden
@@ -29,6 +29,6 @@ Satoshis per vbyte: Traceback (most recent call last):
     source_address, destinations, redeem_script, input_txs)
   File "../../glacierscript.py", line 424, in create_unsigned_transaction
     json.dumps(destinations)).strip()
-  File "../../glacierscript.py", line 124, in bitcoin_cli_checkoutput
+  File "../../glacierscript.py", line 128, in bitcoin_cli_checkoutput
     if retcode != 0: raise subprocess.CalledProcessError(retcode, cmd_list, output=output)
 subprocess.CalledProcessError: Command '['bitcoin-cli', '-testnet', '-rpcport=18340', '-datadir=bitcoin-test-data', 'createrawtransaction', '[{"vout": 1, "txid": "e0e9bb25fb873c4caccdc8ab743c4350310031f2cc077bb90c3f495458860157"}]', '{"2N93du8YobdgsHyu3qgBvSyhGUT52utMNeA": 0, "myP4xdJNwAW9iMakvCjnozg814ewgn8apx": 0}']' returned non-zero exit status 5

--- a/t/create-withdrawal-data.fails.golden
+++ b/t/create-withdrawal-data.fails.golden
@@ -21,7 +21,7 @@ How many private keys will you be signing this transaction with?
 #: Key #1: Key #2: 
 Enter fee rate.
 Satoshis per vbyte: Traceback (most recent call last):
-  File "../../glacierscript.py", line 880, in <module>
+  File "../../glacierscript.py", line 879, in <module>
     withdraw_interactive()
   File "../../glacierscript.py", line 762, in withdraw_interactive
     source_address, keys, addresses, redeem_script, txs)

--- a/t/create-withdrawal-data.fails.run
+++ b/t/create-withdrawal-data.fails.run
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+# Illegal value entered for dest address, bitcoin-cli should fail and cause script abort
+
+
+../../glacierscript.py --testnet=$1 create-withdrawal-data << INPUT 2>&1
+y
+y
+y
+y
+y
+y
+2N93du8YobdgsHyu3qgBvSyhGUT52utMNeA
+522103d14ddcfb6817f5579695bbb3eb3e185887bf2942b031e6f716343b8fe7e9e8e221028fcd46f8614b2cbf318096968242a1e22bcfb6d8f2b6dc939c8c27c347b2937b210315acb550120f4cdcb460d5c49080ab508ca4ccd8dedecac22feeac8cd017d4c121022b063ee2f22f9e1982c140fe778672c683111a796dcccdbd47bb65e3d608a98354ae
+myP4xdJNwAW9iMakvCjnozg814ewgn8apx
+1
+0200000001027a30118f5a29f686071774589a49e27c05963530fd5b52c29cc03d5874e5bd000000006b483045022100d4504530751a274934eae4689d7745ab35fda90d769015b3efdec004dc6055d002207654cf1e67900922c6519493584cfcc12b40ef608853a6f51a171f5d23f5da14012103cad1d192effda236ff8f8f2472ecd68d76c55e1e4416eb31bb689770cc330409feffffff02d3f55b05000000001976a91443187b37dcb5177953d11b1f2272d5b22ab95ff188ac809698000000000017a914ad50fb2489353008e75b0193011ff1f4b76f798c8735901300
+2
+cQCrT9Ncs9729ao7jbmAWrD9z7tF64s2yKzmD6nkiLAi9sXVZWAn
+cP65UeSDZPiTLB6CBwasWv9oJYEjRgQXhswfwcT9HscEKDcEbgy4
+10
+INPUT
+
+retVal=$?
+if [ $retVal -eq 0 ]; then
+    echo "Error: expected glacierscript.py to fail"
+    exit 1
+fi

--- a/t/decode-transactions
+++ b/t/decode-transactions
@@ -24,7 +24,11 @@ for i in create-withdrawal-data.*.golden; do
         if [ "$line" = "Raw signed transaction (hex):" ]; then MATCH=true; fi
 
     done < "$i"
-    bitcoin-cli -testnet decoderawtransaction "$HEX" > "${i/%.golden/.decoded}"
+    if [ "$MATCH" = true ]; then
+        bitcoin-cli -testnet decoderawtransaction "$HEX"
+    else
+        echo "No transaction found"
+    fi > "${i/%.golden/.decoded}"
 done
 
 


### PR DESCRIPTION
This builds on @ak1n's work to add a -v flag to `glacierscript.py` that will show all command-line activity that the script is performing behind the scenes. It will be a useful aid for debugging, auditing, and learning.

Implementing this required a significant refactoring of the way subprocesses are launched, but the resulting code is simplified and more readable (IMO).

As usual I would recommend reviewers analyze each commit individually, to avoid being overwhelmed by all the changes at once.

This subsumes PR #56, which I was trying to improve via @ak1n's fork, but he seems to have disappeared for a while.